### PR TITLE
Update to use ContainerPilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Autopilot Pattern Elasticsearch
 [![ImageLayers](https://badge.imagelayers.io/autopilotpattern/elasticsearch:latest.svg)](https://imagelayers.io/?images=autopilotpattern/elasticsearch:latest)
 [![Join the chat at https://gitter.im/autopilotpattern/general](https://badges.gitter.im/autopilotpattern/general.svg)](https://gitter.im/autopilotpattern/general)
 
-### Discovery with Containerbuddy
+### Discovery with ContainerPilot
 
 Cloud deployments can't take advantage of multicast over the software-defined networks available from AWS, GCE, or Joyent's Triton. Although a separate plugin could be developed to run discovery, in this case we're going to take advantage of a fairly typical production topology for Elasticsearch -- master-only nodes.
 
-When a data node starts, it will use [Containerbuddy](https://github.com/joyent/containerbuddy) to query Consul and find a master node to bootstrap unicast zen discovery. We write this to the node configuration file on each start, so if the bootstrap node dies we can still safely reboot data nodes and join them to whatever master is available.
+When a data node starts, it will use [ContainerPilot](https://github.com/joyent/containerpilot) to query Consul and find a master node to bootstrap unicast zen discovery. We write this to the node configuration file on each start, so if the bootstrap node dies we can still safely reboot data nodes and join them to whatever master is available.
 
 ### Usage
 

--- a/bin/manage.sh
+++ b/bin/manage.sh
@@ -7,7 +7,7 @@ if [[ -z ${CONSUL} ]]; then
     exit 1
 fi
 
-onStart() {
+preStart() {
     # happy path is that there's a master available and we can cluster
     configureMaster
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 # Elasticsearch stack designed for container-native deployment
-# on Joyent's Triton platform.
+# using the Autopilot Pattern on Joyent's Triton platform.
 
 # ---------------------------------------------------
 # This common service definition is the default for nodes that both store
@@ -20,7 +20,6 @@ elasticsearch:
       - ES_HEAP_SIZE=1g # set to 50% of mem_limit, but no more than 31g
       - ES_NODE_MASTER=true # default
       - ES_NODE_DATA=true   # default
-      - CONTAINERBUDDY=file:///etc/containerbuddy.json
 
       # set the number of threads we want based on the number of CPU shares
       # that we'll get for this size container on Triton
@@ -29,7 +28,7 @@ elasticsearch:
       # ES_DIRECT_SIZE  # optional override
 
     command: >
-      /bin/containerbuddy
+      /usr/local/bin/containerpilot
       /usr/share/elasticsearch/bin/elasticsearch
       --default.path.conf=/etc/elasticsearch
 

--- a/etc/containerpilot.json
+++ b/etc/containerpilot.json
@@ -1,11 +1,11 @@
 {
   "consul": "{{ .CONSUL }}:8500",
-  "onStart": "/bin/manage.sh onStart",
+  "preStart": "/usr/local/bin/manage.sh preStart",
   "services": [
     {
       "name": "{{ .ES_SERVICE_NAME }}",
       "port": 9300,
-      "health": "/bin/manage.sh health",
+      "health": "/usr/local/bin/manage.sh health",
       "poll": 10,
       "ttl": 25
     }

--- a/etc/elasticsearch.yml
+++ b/etc/elasticsearch.yml
@@ -86,7 +86,7 @@ network.host: _eth0:ipv4_
 # discovery.zen.minimum_master_nodes: 3
 
 # We'll bootstrap cluster communications by getting a master node via
-# the Containerbuddy `onStart` directive, which will rewrite this
+# the ContainerPilot `preStart` directive, which will rewrite this
 # configuration value with the appropriate hostname.
 
 discovery.zen.ping.multicast.enabled: false

--- a/local-compose.yml
+++ b/local-compose.yml
@@ -12,7 +12,7 @@ elasticsearch_master:
       - ES_SERVICE_NAME=elasticsearch-master
       - ES_NODE_MASTER=true
       - ES_NODE_DATA=false
-      - CONTAINERBUDDY=file:///etc/containerbuddy.json
+      - CONTAINERPILOT=file:///etc/containerpilot.json
     links:
     - consul:consul
 


### PR DESCRIPTION
@misterbisson this PR updates our Elasticsearch image to use ContainerPilot rather than the deprecated Containerbuddy. I've also switched to using the headless JRE here (hadn't realized that was an option previously!), which shaves about 150MB off the image size.
